### PR TITLE
Updated composer json and added php version 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": "~7.1"
+    "php": "~7.1|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": ">=7.0",


### PR DESCRIPTION
As we know PHP is now updated to 8.0 and I'm also using 8.0 for my Laravel 8. I've just added support for PHP 8 in composer.json.
Please review and merge ASAP.